### PR TITLE
Enable parallel runners for golangci-lint

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -33,13 +33,13 @@ tasks:
   lint:
     desc: Run linting tools
     cmds:
-      - golangci-lint run ./...
+      - golangci-lint run --allow-parallel-runners ./...
       - go vet ./...
 
   lint-fix:
     desc: Run linting tools, and apply fixes
     cmds:
-      - golangci-lint run --fix ./...
+      - golangci-lint run --allow-parallel-runners --fix ./...
 
   test:
     desc: Run tests
@@ -63,7 +63,7 @@ tasks:
     desc: Format the code
     cmds:
       - go fmt ./...
-      - golangci-lint run --fix
+      - golangci-lint run --allow-parallel-runners --fix
 
   deps:
     desc: Update dependencies


### PR DESCRIPTION
## Summary
- Add `--allow-parallel-runners` flag to all `golangci-lint run` invocations in the Taskfile
- This allows multiple golangci-lint instances to run simultaneously by preventing the default file lock acquisition at startup

## Test plan
- [ ] Run `task lint` and verify it works as before
- [ ] Run `task lint-fix` and verify it works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)